### PR TITLE
edit JavaScript sample formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,30 +89,27 @@ arguments ```choice1``` and ```choice2```.
 ```javascript
 var compare = function(userChoice, computerChoice) {
     if (userChoice  === computerChoice) {
-          window.alert("The result is a tie!");
-      } else if(userChoice ==="rock") {
-        if (computerChoice==="scissors") {
+        window.alert("The result is a tie!");
+    } else if(userChoice === "rock") {
+        if (computerChoice === "scissors") {
             window.alert("Rock wins!");
-      } else {
+        } else {
             window.alert("Paper wins");
-          }
-      }
-      else if(userChoice==="paper") {
-         if(computerChoice ==="rock") {
-             window.alert("paper wins!");
-         } else {
-             window.alert("scissors wins!");
-         }
-      }
-
-      else if(userChoice==="scissors") {
-          if (computerChoice==="rock") {
-              window.alert("Rock wins");
-          } else {
-              window.alert("scissors wins");
-          }
-      }
-  };
+        }
+    } else if(userChoice === "paper") {
+        if(computerChoice === "rock") {
+            window.alert("paper wins!");
+        } else {
+            window.alert("scissors wins!");
+        }
+    } else if(userChoice === "scissors") {
+        if (computerChoice === "rock") {
+            window.alert("Rock wins");
+        } else {
+            window.alert("scissors wins");
+        }
+    }
+};
 ```
 
 


### PR DESCRIPTION
This PR corrects some whitespace inconsistencies in JavaScript samples found in
the README.
### Background

I noticed some whitespace inconsistencies in the JavaScript samples during a
meetup at Galvanize Fort Collins.
### Screenshots
#### before:

![js_formatting_before](https://cloud.githubusercontent.com/assets/467053/10501382/16da3604-729e-11e5-9b00-db69912b0367.png)
#### after:

![js_formatting_after](https://cloud.githubusercontent.com/assets/467053/10501417/849e35f0-729e-11e5-9ddf-a5b1c512b47f.png)
